### PR TITLE
[PN-19218] - Added EventBridgePublisher instead of queue producer in OutputTargetSender

### DIFF
--- a/config/application.properties
+++ b/config/application.properties
@@ -53,6 +53,10 @@ pn.paper-tracker.ocr-filter-unified-delivery-driver=POSTE
 
 pn.paper-tracker.disable-all-consumers=true
 
+pn.paper-tracker.eventbus.name = paper-tracker-event-bus-name
+pn.paper-tracker.eventbus.detailType = PaperChannelOutcomeEvent
+pn.paper-tracker.eventbus.source = pn-paper-tracker
+
 # application-test.properties
 
 # Spring Cloud AWS 3.x Configuration

--- a/scripts/aws/cfn/microservice.yml
+++ b/scripts/aws/cfn/microservice.yml
@@ -566,6 +566,7 @@ Resources:
         ContainerEnvEntry21: !Sub 'PN_PAPERTRACKER_TOPICS_EXTERNALCHANNELTOPAPERCHANNELQUEUE=${ExternalChannels2PaperChannelQueueName}'
         ContainerEnvEntry22: !Sub 'PN_PAPERTRACKER_TOPICS_EXTERNALCHANNELTOPAPERCHANNELDRYRUNQUEUE=${ExternalChannelsToPaperChannelDryrunQueueName}'
         ContainerEnvEntry23: !Sub 'METRIC_FORMAT_TYPE=${MetricFormatType}'
+        ContainerEnvEntry24: !Sub 'PN_PAPERTRACKER_EVENTBUS_NAME=arn:aws:events:${AWS::Region}:${AWS::AccountId}:event-bus/${ProjectName}-CoreEventBus'
         ApplicativeEnvFileChecksum: !Ref ApplicativeEnvFileChecksum
         MappedPaths: '/paper-tracker/*,/paper-tracker-private/*'
         ECSClusterName: !Ref ECSClusterName
@@ -658,6 +659,11 @@ Resources:
               - !Ref ExternalChannelsOutputsQueueARN
               - !Ref ExternalChannels2PaperChannelQueueARN
               - !Sub 'arn:aws:sqs:${AWS::Region}:${AWS::AccountId}:${ExternalChannelsToPaperChannelDryrunQueueName}'
+          - Effect: Allow
+            Action:
+              - events:PutEvents
+            Resource:
+              - !Sub arn:aws:events:${AWS::Region}:${AWS::AccountId}:event-bus/${ProjectName}-CoreEventBus
 
   # PaperTrackerQueueProxy Lambda
   PaperTrackerQueueProxy:

--- a/src/main/java/it/pagopa/pn/papertracker/config/PnPaperTrackerConfigs.java
+++ b/src/main/java/it/pagopa/pn/papertracker/config/PnPaperTrackerConfigs.java
@@ -49,6 +49,8 @@ public class PnPaperTrackerConfigs {
     private boolean enableTruncatedDateForRefinementCheck;
     private Duration refinementDuration;
 
+    private EventBus eventBus;
+
     @Data
     public static class Dao {
         private String paperTrackingsErrorsTable;
@@ -68,6 +70,13 @@ public class PnPaperTrackerConfigs {
         private String queueOcrInputsRegion;
         private String externalChannelOutputsQueue;
         private String externalChannelToPaperChannelDryRunQueue;
+    }
+
+    @Data
+    public static class EventBus {
+        private String name;
+        private String detailType;
+        private String source;
     }
 
     @PostConstruct

--- a/src/main/java/it/pagopa/pn/papertracker/middleware/eventBridge/EventBridgePublisher.java
+++ b/src/main/java/it/pagopa/pn/papertracker/middleware/eventBridge/EventBridgePublisher.java
@@ -1,0 +1,44 @@
+package it.pagopa.pn.papertracker.middleware.eventBridge;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import it.pagopa.pn.papertracker.config.PnPaperTrackerConfigs;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
+import software.amazon.awssdk.services.eventbridge.EventBridgeAsyncClient;
+import software.amazon.awssdk.services.eventbridge.model.PutEventsRequest;
+import software.amazon.awssdk.services.eventbridge.model.PutEventsRequestEntry;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class EventBridgePublisher {
+
+    private final EventBridgeAsyncClient client;
+    private final ObjectMapper objectMapper;
+    private final PnPaperTrackerConfigs configs;
+
+    public Mono<Void> publish(Object event) {
+        return Mono.fromCallable(() ->
+                        objectMapper.writeValueAsString(event))
+                .flatMap(detail -> Mono.fromFuture(client.putEvents(createRequest(detail))))
+                .doOnError(e -> log.error("EventBridge publish error: {}", e.getMessage()))
+                .doOnNext(response -> log.info("EventBridge publish response: {}", response.entries()))
+                .then();
+    }
+
+    private PutEventsRequest createRequest(String detail) {
+        PutEventsRequestEntry entry = PutEventsRequestEntry.builder()
+                .eventBusName(configs.getEventBus().getName())
+                .source(configs.getEventBus().getSource())
+                .detailType(configs.getEventBus().getDetailType())
+                .detail(detail)
+                .build();
+
+        return PutEventsRequest.builder()
+                .entries(entry)
+                .build();
+    }
+
+}

--- a/src/main/java/it/pagopa/pn/papertracker/service/handler_step/AR/HandlersFactoryAr.java
+++ b/src/main/java/it/pagopa/pn/papertracker/service/handler_step/AR/HandlersFactoryAr.java
@@ -11,7 +11,7 @@ public class HandlersFactoryAr extends AbstractHandlersFactory {
 
     public HandlersFactoryAr(MetadataUpserter metadataUpserter,
                              CheckTrackingProduct checkTrackingProduct,
-                             DeliveryPushSender deliveryPushSender,
+                             OutputTargetSender outputTargetSender,
                              FinalEventBuilderAr finalEventBuilder,
                              IntermediateEventsBuilder intermediateEventsBuilder,
                              DematValidatorAr dematValidator,
@@ -24,7 +24,7 @@ public class HandlersFactoryAr extends AbstractHandlersFactory {
                              RetrySenderCON996 retrySenderCON996) {
         super(metadataUpserter,
                 checkTrackingProduct,
-                deliveryPushSender,
+                outputTargetSender,
                 finalEventBuilder,
                 intermediateEventsBuilder,
                 dematValidator,

--- a/src/main/java/it/pagopa/pn/papertracker/service/handler_step/RIR/HandlersFactoryRir.java
+++ b/src/main/java/it/pagopa/pn/papertracker/service/handler_step/RIR/HandlersFactoryRir.java
@@ -12,7 +12,7 @@ public class HandlersFactoryRir extends AbstractHandlersFactory {
 
     public HandlersFactoryRir(MetadataUpserter metadataUpserter,
                               CheckTrackingProduct checkTrackingProduct,
-                              DeliveryPushSender deliveryPushSender,
+                              OutputTargetSender outputTargetSender,
                               FinalEventBuilderRir finalEventBuilder,
                               IntermediateEventsBuilder intermediateEventsBuilder,
                               DematValidatorRir dematValidator,
@@ -25,7 +25,7 @@ public class HandlersFactoryRir extends AbstractHandlersFactory {
                               RetrySenderCON996 retrySenderCON996) {
         super(metadataUpserter,
                 checkTrackingProduct,
-                deliveryPushSender,
+                outputTargetSender,
                 finalEventBuilder,
                 intermediateEventsBuilder,
                 dematValidator,

--- a/src/main/java/it/pagopa/pn/papertracker/service/handler_step/RIS/HandlersFactoryRis.java
+++ b/src/main/java/it/pagopa/pn/papertracker/service/handler_step/RIS/HandlersFactoryRis.java
@@ -9,7 +9,7 @@ public class HandlersFactoryRis extends AbstractHandlersFactory {
 
     public HandlersFactoryRis(MetadataUpserter metadataUpserter,
                               CheckTrackingProduct checkTrackingProduct,
-                              DeliveryPushSender deliveryPushSender,
+                              OutputTargetSender outputTargetSender,
                               FinalEventBuilderRis finalEventBuilder,
                               IntermediateEventsBuilder intermediateEventsBuilder,
                               DematValidatorRis dematValidator,
@@ -22,7 +22,7 @@ public class HandlersFactoryRis extends AbstractHandlersFactory {
                               RetrySenderCON996 retrySenderCON996) {
         super(metadataUpserter,
                 checkTrackingProduct,
-                deliveryPushSender,
+                outputTargetSender,
                 finalEventBuilder,
                 intermediateEventsBuilder,
                 dematValidator,

--- a/src/main/java/it/pagopa/pn/papertracker/service/handler_step/RS/HandlersFactoryRs.java
+++ b/src/main/java/it/pagopa/pn/papertracker/service/handler_step/RS/HandlersFactoryRs.java
@@ -9,7 +9,7 @@ public class HandlersFactoryRs extends AbstractHandlersFactory {
 
     public HandlersFactoryRs(MetadataUpserter metadataUpserter,
                              CheckTrackingProduct checkTrackingProduct,
-                             DeliveryPushSender deliveryPushSender,
+                             OutputTargetSender outputTargetSender,
                              FinalEventBuilderRs finalEventBuilder,
                              IntermediateEventsBuilder intermediateEventsBuilder,
                              DematValidatorRs dematValidator,
@@ -22,7 +22,7 @@ public class HandlersFactoryRs extends AbstractHandlersFactory {
                              RetrySenderCON996 retrySenderCON996) {
         super(metadataUpserter,
                 checkTrackingProduct,
-                deliveryPushSender,
+                outputTargetSender,
                 finalEventBuilder,
                 intermediateEventsBuilder,
                 dematValidator,

--- a/src/main/java/it/pagopa/pn/papertracker/service/handler_step/_890/HandlersFactory890.java
+++ b/src/main/java/it/pagopa/pn/papertracker/service/handler_step/_890/HandlersFactory890.java
@@ -23,7 +23,7 @@ public class HandlersFactory890 extends AbstractHandlersFactory {
     public HandlersFactory890(
             MetadataUpserter metadataUpserter,
             CheckTrackingProduct checkTrackingProduct,
-            DeliveryPushSender deliveryPushSender,
+            OutputTargetSender outputTargetSender,
             FinalEventBuilder890 finalEventBuilder,
             IntermediateEventsBuilder intermediateEventsBuilder,
             DematValidator890 dematValidator,
@@ -41,7 +41,7 @@ public class HandlersFactory890 extends AbstractHandlersFactory {
         super(
                 metadataUpserter,
                 checkTrackingProduct,
-                deliveryPushSender,
+                outputTargetSender,
                 finalEventBuilder,
                 intermediateEventsBuilder,
                 dematValidator,
@@ -83,7 +83,7 @@ public class HandlersFactory890 extends AbstractHandlersFactory {
                         recag012EventChecker,
                         intermediateEventsBuilder,
                         recag012EventBuilder,
-                        deliveryPushSender
+                        outputTargetSender
                 ));
     }
 
@@ -94,7 +94,7 @@ public class HandlersFactory890 extends AbstractHandlersFactory {
                         checkTrackingState,
                         recag012EventChecker,
                         recag012EventBuilder,
-                        deliveryPushSender
+                        outputTargetSender
                 ));
     }
 
@@ -104,12 +104,12 @@ public class HandlersFactory890 extends AbstractHandlersFactory {
                         checkOcrResponse,
                         finalEventBuilder,
                         recag012EventBuilder,
-                        deliveryPushSender,
+                        outputTargetSender,
                         pendingFinalEventTrigger,
                         sequenceValidator,
                         dematValidator,
                         finalEventBuilder,
-                        deliveryPushSender
+                        outputTargetSender
                 ));
     }
 }

--- a/src/main/java/it/pagopa/pn/papertracker/service/handler_step/generic/AbstractHandlersFactory.java
+++ b/src/main/java/it/pagopa/pn/papertracker/service/handler_step/generic/AbstractHandlersFactory.java
@@ -19,7 +19,7 @@ import java.util.function.Function;
 public abstract class AbstractHandlersFactory implements HandlersFactory {
     protected final MetadataUpserter metadataUpserter;
     protected final CheckTrackingProduct checkTrackingProduct;
-    protected final DeliveryPushSender deliveryPushSender;
+    protected final OutputTargetSender outputTargetSender;
     protected final GenericFinalEventBuilder finalEventBuilder;
     protected final IntermediateEventsBuilder intermediateEventsBuilder;
     protected final GenericDematValidator dematValidator;
@@ -79,7 +79,7 @@ public abstract class AbstractHandlersFactory implements HandlersFactory {
                         sequenceValidator,
                         dematValidator,
                         finalEventBuilder,
-                        deliveryPushSender
+                        outputTargetSender
                 ));
     }
 
@@ -103,7 +103,7 @@ public abstract class AbstractHandlersFactory implements HandlersFactory {
                         checkTrackingState,
                         duplicatedEventFiltering,
                         intermediateEventsBuilder,
-                        deliveryPushSender
+                        outputTargetSender
                 ));
     }
 
@@ -130,7 +130,7 @@ public abstract class AbstractHandlersFactory implements HandlersFactory {
                         checkTrackingState,
                         retrySender,
                         intermediateEventsBuilder,
-                        deliveryPushSender
+                        outputTargetSender
                 ));
     }
 
@@ -156,7 +156,7 @@ public abstract class AbstractHandlersFactory implements HandlersFactory {
                         duplicatedEventFiltering,
                         notRetryableErrorInserting,
                         intermediateEventsBuilder,
-                        deliveryPushSender
+                        outputTargetSender
                 ));
     }
 
@@ -177,7 +177,7 @@ public abstract class AbstractHandlersFactory implements HandlersFactory {
                 List.of(
                         checkOcrResponse,
                         finalEventBuilder,
-                        deliveryPushSender
+                        outputTargetSender
                 ));
     }
 
@@ -214,7 +214,7 @@ public abstract class AbstractHandlersFactory implements HandlersFactory {
                         duplicatedEventFiltering,
                         retrySenderCON996,
                         intermediateEventsBuilder,
-                        deliveryPushSender
+                        outputTargetSender
                 ));
     }
 }

--- a/src/main/java/it/pagopa/pn/papertracker/service/handler_step/generic/OutputTargetSender.java
+++ b/src/main/java/it/pagopa/pn/papertracker/service/handler_step/generic/OutputTargetSender.java
@@ -1,6 +1,5 @@
 package it.pagopa.pn.papertracker.service.handler_step.generic;
 
-import it.pagopa.pn.api.dto.events.GenericEventHeader;
 import it.pagopa.pn.papertracker.config.PnPaperTrackerConfigs;
 import it.pagopa.pn.papertracker.generated.openapi.msclient.paperchannel.model.PaperChannelUpdate;
 import it.pagopa.pn.papertracker.generated.openapi.msclient.paperchannel.model.SendEvent;
@@ -11,8 +10,7 @@ import it.pagopa.pn.papertracker.middleware.dao.dynamo.entity.BusinessState;
 import it.pagopa.pn.papertracker.middleware.dao.dynamo.entity.PaperStatus;
 import it.pagopa.pn.papertracker.middleware.dao.dynamo.entity.PaperTrackings;
 import it.pagopa.pn.papertracker.middleware.dao.dynamo.entity.PaperTrackingsState;
-import it.pagopa.pn.papertracker.middleware.queue.model.DeliveryPushEvent;
-import it.pagopa.pn.papertracker.middleware.queue.producer.ExternalChannelOutputsMomProducer;
+import it.pagopa.pn.papertracker.middleware.eventBridge.EventBridgePublisher;
 import it.pagopa.pn.papertracker.model.HandlerContext;
 import it.pagopa.pn.papertracker.service.handler_step.HandlerStep;
 import it.pagopa.pn.papertracker.utils.LogUtility;
@@ -24,24 +22,21 @@ import org.springframework.util.StringUtils;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
-import java.time.Instant;
 import java.util.List;
-import java.util.UUID;
 
 import static it.pagopa.pn.papertracker.generated.openapi.msclient.paperchannel.model.SendEvent.JSON_PROPERTY_DISCOVERED_ADDRESS;
-import static it.pagopa.pn.papertracker.utils.QueueConst.DELIVERY_PUSH_EVENT_TYPE;
-import static it.pagopa.pn.papertracker.utils.QueueConst.PUBLISHER;
 import static it.pagopa.pn.papertracker.utils.TrackerUtility.setNewStatus;
 
 @Slf4j
 @RequiredArgsConstructor
 @Component
-public class DeliveryPushSender implements HandlerStep {
+public class OutputTargetSender implements HandlerStep {
 
+    private final String CLIENT_ID = "pn-delivery-push-workflow";
     private final PnPaperTrackerConfigs configs;
     private final PaperTrackerDryRunOutputsDAO paperTrackerDryRunOutputsDAO;
     private final PaperTrackingsDAO paperTrackingsDAO;
-    private final ExternalChannelOutputsMomProducer externalChannelOutputsMomProducer;
+    private final EventBridgePublisher eventBridgePublisher;
     private final LogUtility logUtility;
 
     /**
@@ -51,14 +46,14 @@ public class DeliveryPushSender implements HandlerStep {
      */
     @Override
     public Mono<Void> execute(HandlerContext context) {
-        log.info("Executing DeliveryPushSender step for trackingId: {}", context.getTrackingId());
+        log.info("Executing OutputTargetSender step for trackingId: {}", context.getTrackingId());
 
         List<SendEvent> filteredEvent = context.getEventsToSend().stream()
                 .filter(sendEvent -> !configs.getSaveAndNotSendToDeliveryPush().contains(sendEvent.getStatusDetail()))
                 .toList();
 
         if (CollectionUtils.isEmpty(filteredEvent)) {
-            log.info("No events to send for trackingId: {}. Skipping DeliveryPushSender step.", context.getTrackingId());
+            log.info("No events to send for trackingId: {}. Skipping OutputTargetSender step.", context.getTrackingId());
             return Mono.empty();
         }
 
@@ -84,24 +79,18 @@ public class DeliveryPushSender implements HandlerStep {
         return Mono.just(event)
                 .flatMap(sendEvent -> {
                     String anonymizedEvent = logUtility.maskSensitiveData(sendEvent, JSON_PROPERTY_DISCOVERED_ADDRESS);
-                    log.info("Sending delivery push for event: {}", anonymizedEvent);
+                    log.info("Sending to output target for event: {}", anonymizedEvent);
                     if (context.isDryRunEnabled()) {
                         log.info("Sending event to PnPaperTrackerDryRunOutputs");
                         return paperTrackerDryRunOutputsDAO.insertOutputEvent(PaperTrackerDryRunOutputsMapper.dtoToEntity(sendEvent, context.getAnonymizedDiscoveredAddressId()));
                     } else {
                         log.info("Sending event to pn-external_channel_outputs");
                         sendEvent.setRequestId(context.getPaperTrackings().getAttemptId());
-                        DeliveryPushEvent deliveryPushEvent = DeliveryPushEvent
-                                .builder()
-                                .payload(PaperChannelUpdate.builder().sendEvent(sendEvent).build())
-                                .header( GenericEventHeader.builder()
-                                        .publisher(PUBLISHER)
-                                        .eventId(UUID.randomUUID().toString())
-                                        .createdAt( Instant.now() )
-                                        .eventType(DELIVERY_PUSH_EVENT_TYPE)
-                                        .build())
-                                .build();
-                        externalChannelOutputsMomProducer.push(deliveryPushEvent);
+                        PaperChannelUpdate paperChannelUpdate = new PaperChannelUpdate();
+                        paperChannelUpdate.setSendEvent(sendEvent);
+                        paperChannelUpdate.setClientId(StringUtils.hasText(context.getPaperTrackings().getAnalogRequestClientId()) ?
+                                context.getPaperTrackings().getAnalogRequestClientId() : CLIENT_ID);
+                        eventBridgePublisher.publish(paperChannelUpdate);
                         return Mono.empty();
                     }
                 })

--- a/src/main/java/it/pagopa/pn/papertracker/service/handler_step/generic/OutputTargetSender.java
+++ b/src/main/java/it/pagopa/pn/papertracker/service/handler_step/generic/OutputTargetSender.java
@@ -32,7 +32,7 @@ import static it.pagopa.pn.papertracker.utils.TrackerUtility.setNewStatus;
 @Component
 public class OutputTargetSender implements HandlerStep {
 
-    private final String CLIENT_ID = "pn-delivery-push-workflow";
+    private final String CLIENT_ID = "pn-delivery-push";
     private final PnPaperTrackerConfigs configs;
     private final PaperTrackerDryRunOutputsDAO paperTrackerDryRunOutputsDAO;
     private final PaperTrackingsDAO paperTrackingsDAO;

--- a/src/test/java/it/pagopa/pn/papertracker/middleware/eventBridge/EventBridgePublisherTest.java
+++ b/src/test/java/it/pagopa/pn/papertracker/middleware/eventBridge/EventBridgePublisherTest.java
@@ -1,0 +1,83 @@
+package it.pagopa.pn.papertracker.middleware.eventBridge;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import it.pagopa.pn.papertracker.config.PnPaperTrackerConfigs;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.test.StepVerifier;
+import software.amazon.awssdk.services.eventbridge.EventBridgeAsyncClient;
+import software.amazon.awssdk.services.eventbridge.model.PutEventsRequest;
+import software.amazon.awssdk.services.eventbridge.model.PutEventsResponse;
+
+import java.util.concurrent.CompletableFuture;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class EventBridgePublisherTest {
+
+    @Mock
+    private EventBridgeAsyncClient client;
+
+    @Mock
+    private ObjectMapper objectMapper;
+
+    @Mock
+    private PnPaperTrackerConfigs configs;
+
+    @InjectMocks
+    private EventBridgePublisher publisher;
+
+    @Test
+    void publishSuccessfully() throws JsonProcessingException {
+        Object event = new Object();
+        String eventDetail = "{\"key\":\"value\"}";
+        PutEventsResponse response = PutEventsResponse.builder().build();
+
+        when(configs.getEventBus()).thenReturn(new PnPaperTrackerConfigs.EventBus());
+        when(objectMapper.writeValueAsString(event)).thenReturn(eventDetail);
+        when(client.putEvents(any(PutEventsRequest.class)))
+                .thenReturn(CompletableFuture.completedFuture(response));
+
+        StepVerifier.create(publisher.publish(event))
+                .verifyComplete();
+
+        verify(client, times(1)).putEvents(any(PutEventsRequest.class));
+    }
+
+    @Test
+    void publishWithSerializationError() throws JsonProcessingException {
+        Object event = new Object();
+
+        when(objectMapper.writeValueAsString(event)).thenThrow(new JsonProcessingException("Serialization error") {
+        });
+
+        StepVerifier.create(publisher.publish(event))
+                .expectError(JsonProcessingException.class)
+                .verify();
+
+        verify(client, never()).putEvents(any(PutEventsRequest.class));
+    }
+
+    @Test
+    void publishWithClientError() throws JsonProcessingException {
+        Object event = new Object();
+        String eventDetail = "{\"key\":\"value\"}";
+
+        when(configs.getEventBus()).thenReturn(new PnPaperTrackerConfigs.EventBus());
+        when(objectMapper.writeValueAsString(event)).thenReturn(eventDetail);
+        when(client.putEvents(any(PutEventsRequest.class)))
+                .thenReturn(CompletableFuture.failedFuture(new RuntimeException("Client error")));
+
+        StepVerifier.create(publisher.publish(event))
+                .expectError(RuntimeException.class)
+                .verify();
+
+        verify(client, times(1)).putEvents(any(PutEventsRequest.class));
+    }
+}

--- a/src/test/java/it/pagopa/pn/papertracker/service/handler_step/AR/HandlersFactoryArTest.java
+++ b/src/test/java/it/pagopa/pn/papertracker/service/handler_step/AR/HandlersFactoryArTest.java
@@ -47,7 +47,7 @@ class HandlersFactoryArTest {
     private RetrySender retrySender;
 
     @Mock
-    private DeliveryPushSender deliveryPushSender;
+    private OutputTargetSender outputTargetSender;
 
     @Mock
     private IntermediateEventsBuilder intermediateEventsBuilder;
@@ -87,7 +87,7 @@ class HandlersFactoryArTest {
         when(checkTrackingProduct.execute(handlerContext)).thenReturn(Mono.empty());
         when(checkTrackingState.execute(handlerContext)).thenReturn(Mono.empty());
         when(duplicatedEventFiltering.execute(handlerContext)).thenReturn(Mono.empty());
-        when(deliveryPushSender.execute(handlerContext)).thenReturn(Mono.empty());
+        when(outputTargetSender.execute(handlerContext)).thenReturn(Mono.empty());
         when(intermediateEventsBuilder.execute(handlerContext)).thenReturn(Mono.empty());
 
 
@@ -96,12 +96,12 @@ class HandlersFactoryArTest {
                 .verifyComplete();
 
         // Verify execution order
-        InOrder inOrder = inOrder(metadataUpserter, checkTrackingProduct, checkTrackingState,duplicatedEventFiltering, deliveryPushSender, intermediateEventsBuilder);
+        InOrder inOrder = inOrder(metadataUpserter, checkTrackingProduct, checkTrackingState,duplicatedEventFiltering, outputTargetSender, intermediateEventsBuilder);
         inOrder.verify(metadataUpserter).execute(handlerContext);
         inOrder.verify(checkTrackingProduct).execute(handlerContext);
         inOrder.verify(checkTrackingState).execute(handlerContext);
         inOrder.verify(duplicatedEventFiltering).execute(handlerContext);
-        inOrder.verify(deliveryPushSender).execute(handlerContext);
+        inOrder.verify(outputTargetSender).execute(handlerContext);
     }
 
     @Test
@@ -135,21 +135,21 @@ class HandlersFactoryArTest {
         when(sequenceValidatorAr.execute(handlerContext)).thenReturn(Mono.empty());
         when(dematValidator.execute(handlerContext)).thenReturn(Mono.empty());
         when(finalEventBuilder.execute(handlerContext)).thenReturn(Mono.empty());
-        when(deliveryPushSender.execute(handlerContext)).thenReturn(Mono.empty());
+        when(outputTargetSender.execute(handlerContext)).thenReturn(Mono.empty());
 
         // Act
         StepVerifier.create(handlersFactoryAr.buildFinalEventsHandler(handlerContext).execute(handlerContext))
                 .verifyComplete();
 
         // Assert
-        InOrder inOrder = inOrder(metadataUpserter, checkTrackingProduct, checkTrackingState, sequenceValidatorAr, dematValidator, finalEventBuilder, deliveryPushSender);
+        InOrder inOrder = inOrder(metadataUpserter, checkTrackingProduct, checkTrackingState, sequenceValidatorAr, dematValidator, finalEventBuilder, outputTargetSender);
         inOrder.verify(metadataUpserter).execute(handlerContext);
         inOrder.verify(checkTrackingProduct).execute(handlerContext);
         inOrder.verify(checkTrackingState).execute(handlerContext);
         inOrder.verify(sequenceValidatorAr).execute(handlerContext);
         inOrder.verify(dematValidator).execute(handlerContext);
         inOrder.verify(finalEventBuilder).execute(handlerContext);
-        inOrder.verify(deliveryPushSender).execute(handlerContext);
+        inOrder.verify(outputTargetSender).execute(handlerContext);
     }
 
     @Test
@@ -158,7 +158,7 @@ class HandlersFactoryArTest {
         when(metadataUpserter.execute(handlerContext)).thenReturn(Mono.empty());
         when(checkTrackingProduct.execute(handlerContext)).thenReturn(Mono.empty());
         when(checkTrackingState.execute(handlerContext)).thenReturn(Mono.empty());
-        when(deliveryPushSender.execute(handlerContext)).thenReturn(Mono.empty());
+        when(outputTargetSender.execute(handlerContext)).thenReturn(Mono.empty());
         when(intermediateEventsBuilder.execute(handlerContext)).thenReturn(Mono.empty());
         when(duplicatedEventFiltering.execute(handlerContext)).thenReturn(Mono.empty());
 
@@ -168,13 +168,13 @@ class HandlersFactoryArTest {
                 .verifyComplete();
 
         // Verify both steps were executed in the correct order
-        InOrder inOrder = inOrder(metadataUpserter, checkTrackingProduct, checkTrackingState, duplicatedEventFiltering, intermediateEventsBuilder, deliveryPushSender);
+        InOrder inOrder = inOrder(metadataUpserter, checkTrackingProduct, checkTrackingState, duplicatedEventFiltering, intermediateEventsBuilder, outputTargetSender);
         inOrder.verify(metadataUpserter).execute(handlerContext);
         inOrder.verify(checkTrackingProduct).execute(handlerContext);
         inOrder.verify(checkTrackingState).execute(handlerContext);
         inOrder.verify(duplicatedEventFiltering).execute(handlerContext);
         inOrder.verify(intermediateEventsBuilder).execute(handlerContext);
-        inOrder.verify(deliveryPushSender).execute(handlerContext);
+        inOrder.verify(outputTargetSender).execute(handlerContext);
     }
 
     @Test
@@ -184,7 +184,7 @@ class HandlersFactoryArTest {
         when(checkTrackingProduct.execute(handlerContext)).thenReturn(Mono.empty());
         when(checkTrackingState.execute(handlerContext)).thenReturn(Mono.empty());
         when(retrySender.execute(handlerContext)).thenReturn(Mono.empty());
-        when(deliveryPushSender.execute(handlerContext)).thenReturn(Mono.empty());
+        when(outputTargetSender.execute(handlerContext)).thenReturn(Mono.empty());
         when(intermediateEventsBuilder.execute(handlerContext)).thenReturn(Mono.empty());
         // Act
         StepVerifier.create(handlersFactoryAr.buildRetryEventHandler(handlerContext).execute(handlerContext))
@@ -205,7 +205,7 @@ class HandlersFactoryArTest {
         when(checkTrackingProduct.execute(handlerContext)).thenReturn(Mono.empty());
         when(checkTrackingState.execute(handlerContext)).thenReturn(Mono.empty());
         when(duplicatedEventFiltering.execute(handlerContext)).thenReturn(Mono.empty());
-        when(deliveryPushSender.execute(handlerContext)).thenReturn(Mono.empty());
+        when(outputTargetSender.execute(handlerContext)).thenReturn(Mono.empty());
         when(intermediateEventsBuilder.execute(handlerContext)).thenReturn(Mono.empty());
         when(notRetryableErrorInserting.execute(handlerContext)).thenReturn(Mono.empty());
 
@@ -214,14 +214,14 @@ class HandlersFactoryArTest {
                 .verifyComplete();
 
         // Assert
-        InOrder inOrder = inOrder(metadataUpserter, checkTrackingProduct, checkTrackingState, duplicatedEventFiltering, notRetryableErrorInserting, intermediateEventsBuilder, deliveryPushSender);
+        InOrder inOrder = inOrder(metadataUpserter, checkTrackingProduct, checkTrackingState, duplicatedEventFiltering, notRetryableErrorInserting, intermediateEventsBuilder, outputTargetSender);
         inOrder.verify(metadataUpserter).execute(handlerContext);
         inOrder.verify(checkTrackingProduct).execute(handlerContext);
         inOrder.verify(checkTrackingState).execute(handlerContext);
         inOrder.verify(duplicatedEventFiltering).execute(handlerContext);
         inOrder.verify(notRetryableErrorInserting).execute(handlerContext);
         inOrder.verify(intermediateEventsBuilder).execute(handlerContext);
-        inOrder.verify(deliveryPushSender).execute(handlerContext);
+        inOrder.verify(outputTargetSender).execute(handlerContext);
     }
 
     @Test
@@ -229,7 +229,7 @@ class HandlersFactoryArTest {
         // Arrange
         when(checkOcrResponse.execute(handlerContext)).thenReturn(Mono.empty());
         when(finalEventBuilder.execute(handlerContext)).thenReturn(Mono.empty());
-        when(deliveryPushSender.execute(handlerContext)).thenReturn(Mono.empty());
+        when(outputTargetSender.execute(handlerContext)).thenReturn(Mono.empty());
         // Act & Assert
         StepVerifier.create(handlersFactoryAr.buildOcrResponseHandler(handlerContext).execute(handlerContext))
                 .verifyComplete();
@@ -242,7 +242,7 @@ class HandlersFactoryArTest {
         when(checkTrackingProduct.execute(handlerContext)).thenReturn(Mono.empty());
         when(checkTrackingState.execute(handlerContext)).thenReturn(Mono.empty());
         when(duplicatedEventFiltering.execute(handlerContext)).thenReturn(Mono.empty());
-        when(deliveryPushSender.execute(handlerContext)).thenReturn(Mono.empty());
+        when(outputTargetSender.execute(handlerContext)).thenReturn(Mono.empty());
         when(intermediateEventsBuilder.execute(handlerContext)).thenReturn(Mono.empty());
 
         // Act & Assert
@@ -258,7 +258,7 @@ class HandlersFactoryArTest {
         when(checkTrackingProduct.execute(handlerContext)).thenReturn(Mono.empty());
         when(checkTrackingState.execute(handlerContext)).thenReturn(Mono.empty());
         when(duplicatedEventFiltering.execute(handlerContext)).thenReturn(Mono.empty());
-        when(deliveryPushSender.execute(handlerContext)).thenReturn(Mono.empty());
+        when(outputTargetSender.execute(handlerContext)).thenReturn(Mono.empty());
         when(intermediateEventsBuilder.execute(handlerContext)).thenReturn(Mono.empty());
 
         // Act
@@ -266,12 +266,12 @@ class HandlersFactoryArTest {
                 .verifyComplete();
 
         // Assert - verify the same context instance is passed to all steps
-        InOrder inOrder = inOrder(metadataUpserter, checkTrackingProduct, checkTrackingState,duplicatedEventFiltering, deliveryPushSender, intermediateEventsBuilder);
+        InOrder inOrder = inOrder(metadataUpserter, checkTrackingProduct, checkTrackingState,duplicatedEventFiltering, outputTargetSender, intermediateEventsBuilder);
         inOrder.verify(metadataUpserter).execute(handlerContext);
         inOrder.verify(checkTrackingProduct).execute(handlerContext);
         inOrder.verify(checkTrackingState).execute(handlerContext);
         inOrder.verify(duplicatedEventFiltering).execute(handlerContext);
-        inOrder.verify(deliveryPushSender).execute(handlerContext);
+        inOrder.verify(outputTargetSender).execute(handlerContext);
     }
 
     @Test

--- a/src/test/java/it/pagopa/pn/papertracker/service/handler_step/AR/RECRN003CMessageHandlerTest.java
+++ b/src/test/java/it/pagopa/pn/papertracker/service/handler_step/AR/RECRN003CMessageHandlerTest.java
@@ -3,6 +3,7 @@ package it.pagopa.pn.papertracker.service.handler_step.AR;
 import it.pagopa.pn.papertracker.BaseTest;
 import it.pagopa.pn.papertracker.exception.PaperTrackerExceptionHandler;
 import it.pagopa.pn.papertracker.generated.openapi.msclient.externalchannel.model.PaperProgressStatusEvent;
+import it.pagopa.pn.papertracker.generated.openapi.msclient.paperchannel.model.PaperChannelUpdate;
 import it.pagopa.pn.papertracker.generated.openapi.msclient.paperchannel.model.SendEvent;
 import it.pagopa.pn.papertracker.generated.openapi.msclient.externalchannel.model.SingleStatusUpdate;
 import it.pagopa.pn.papertracker.generated.openapi.msclient.paperchannel.model.StatusCodeEnum;
@@ -11,12 +12,11 @@ import it.pagopa.pn.papertracker.middleware.dao.PaperTrackingsDAO;
 import it.pagopa.pn.papertracker.middleware.dao.PaperTrackingsErrorsDAO;
 import it.pagopa.pn.papertracker.middleware.dao.dynamo.entity.Attachment;
 import it.pagopa.pn.papertracker.middleware.dao.dynamo.entity.Event;
+import it.pagopa.pn.papertracker.middleware.eventBridge.EventBridgePublisher;
 import it.pagopa.pn.papertracker.middleware.msclient.DataVaultClient;
 import it.pagopa.pn.papertracker.middleware.msclient.PaperChannelClient;
 import it.pagopa.pn.papertracker.middleware.msclient.SafeStorageClient;
 import it.pagopa.pn.papertracker.middleware.queue.consumer.internal.ExternalChannelHandler;
-import it.pagopa.pn.papertracker.middleware.queue.model.DeliveryPushEvent;
-import it.pagopa.pn.papertracker.middleware.queue.producer.ExternalChannelOutputsMomProducer;
 import it.pagopa.pn.papertracker.service.handler_step.RIR.HandlersFactoryRir;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Assertions;
@@ -76,7 +76,7 @@ class RECRN003CMessageHandlerTest extends BaseTest.WithLocalStack {
     @MockitoBean
     private DataVaultClient dataVaultClient;
     @MockitoBean
-    private ExternalChannelOutputsMomProducer externalChannelOutputsMomProducer;
+    private EventBridgePublisher eventBridgePublisher;
 
 
     @Test
@@ -106,19 +106,19 @@ class RECRN003CMessageHandlerTest extends BaseTest.WithLocalStack {
         SingleStatusUpdate singleStatusUpdate = new SingleStatusUpdate();
         singleStatusUpdate.setAnalogMail(paperRequest);
 
-        ArgumentCaptor<DeliveryPushEvent> capturedSendEvent = ArgumentCaptor.forClass(DeliveryPushEvent.class);
+        ArgumentCaptor<PaperChannelUpdate> capturedSendEvent = ArgumentCaptor.forClass(PaperChannelUpdate.class);
 
         // Act
         externalChannelHandler.handleExternalChannelMessage(singleStatusUpdate, false, null, eventId, null);
 
         // Assert
-        verify(externalChannelOutputsMomProducer, times(2)).push(capturedSendEvent.capture());
+        verify(eventBridgePublisher, times(2)).publish(capturedSendEvent.capture());
         assertNotNull(capturedSendEvent.getAllValues());
         assertEquals(2, capturedSendEvent.getAllValues().size());
-        assertEquals(STATUS_PNRN012, Objects.requireNonNull(capturedSendEvent.getAllValues().get(0).getPayload().getSendEvent()).getStatusDetail());
-        assertEquals(StatusCodeEnum.OK, Objects.requireNonNull(capturedSendEvent.getAllValues().get(0).getPayload().getSendEvent()).getStatusCode());
-        assertEquals(STATUS_RECRN003C, Objects.requireNonNull(capturedSendEvent.getAllValues().get(1).getPayload().getSendEvent()).getStatusDetail());
-        assertEquals(StatusCodeEnum.PROGRESS, Objects.requireNonNull(capturedSendEvent.getAllValues().get(1).getPayload().getSendEvent()).getStatusCode());
+        assertEquals(STATUS_PNRN012, Objects.requireNonNull(capturedSendEvent.getAllValues().get(0).getSendEvent()).getStatusDetail());
+        assertEquals(StatusCodeEnum.OK, Objects.requireNonNull(capturedSendEvent.getAllValues().get(0).getSendEvent()).getStatusCode());
+        assertEquals(STATUS_RECRN003C, Objects.requireNonNull(capturedSendEvent.getAllValues().get(1).getSendEvent()).getStatusDetail());
+        assertEquals(StatusCodeEnum.PROGRESS, Objects.requireNonNull(capturedSendEvent.getAllValues().get(1).getSendEvent()).getStatusCode());
     }
 
     @Test
@@ -148,16 +148,16 @@ class RECRN003CMessageHandlerTest extends BaseTest.WithLocalStack {
         SingleStatusUpdate singleStatusUpdate = new SingleStatusUpdate();
         singleStatusUpdate.setAnalogMail(paperRequest);
 
-        ArgumentCaptor<DeliveryPushEvent> capturedSendEvent = ArgumentCaptor.forClass(DeliveryPushEvent.class);
+        ArgumentCaptor<PaperChannelUpdate> capturedSendEvent = ArgumentCaptor.forClass(PaperChannelUpdate.class);
 
         // Act
         externalChannelHandler.handleExternalChannelMessage(singleStatusUpdate, false, null, eventId, null);
 
         // Assert
-        verify(externalChannelOutputsMomProducer).push(capturedSendEvent.capture());
+        verify(eventBridgePublisher).publish(capturedSendEvent.capture());
         log.info(capturedSendEvent.getAllValues().toString());
         assertNotNull(capturedSendEvent.getAllValues());
-        SendEvent sendEvent = capturedSendEvent.getValue().getPayload().getSendEvent();
+        SendEvent sendEvent = capturedSendEvent.getValue().getSendEvent();
         assertNotNull(sendEvent);
         Assertions.assertEquals(StatusCodeEnum.OK, sendEvent.getStatusCode());
         Assertions.assertEquals(STATUS_RECRN003C, sendEvent.getStatusDetail());

--- a/src/test/java/it/pagopa/pn/papertracker/service/handler_step/AR/RECRN004CMessageHandlerTest.java
+++ b/src/test/java/it/pagopa/pn/papertracker/service/handler_step/AR/RECRN004CMessageHandlerTest.java
@@ -3,6 +3,7 @@ package it.pagopa.pn.papertracker.service.handler_step.AR;
 import it.pagopa.pn.papertracker.BaseTest;
 import it.pagopa.pn.papertracker.exception.PaperTrackerExceptionHandler;
 import it.pagopa.pn.papertracker.generated.openapi.msclient.externalchannel.model.PaperProgressStatusEvent;
+import it.pagopa.pn.papertracker.generated.openapi.msclient.paperchannel.model.PaperChannelUpdate;
 import it.pagopa.pn.papertracker.generated.openapi.msclient.paperchannel.model.SendEvent;
 import it.pagopa.pn.papertracker.generated.openapi.msclient.externalchannel.model.SingleStatusUpdate;
 import it.pagopa.pn.papertracker.generated.openapi.msclient.paperchannel.model.StatusCodeEnum;
@@ -11,12 +12,11 @@ import it.pagopa.pn.papertracker.middleware.dao.PaperTrackingsDAO;
 import it.pagopa.pn.papertracker.middleware.dao.PaperTrackingsErrorsDAO;
 import it.pagopa.pn.papertracker.middleware.dao.dynamo.entity.Attachment;
 import it.pagopa.pn.papertracker.middleware.dao.dynamo.entity.Event;
+import it.pagopa.pn.papertracker.middleware.eventBridge.EventBridgePublisher;
 import it.pagopa.pn.papertracker.middleware.msclient.DataVaultClient;
 import it.pagopa.pn.papertracker.middleware.msclient.PaperChannelClient;
 import it.pagopa.pn.papertracker.middleware.msclient.SafeStorageClient;
 import it.pagopa.pn.papertracker.middleware.queue.consumer.internal.ExternalChannelHandler;
-import it.pagopa.pn.papertracker.middleware.queue.model.DeliveryPushEvent;
-import it.pagopa.pn.papertracker.middleware.queue.producer.ExternalChannelOutputsMomProducer;
 import it.pagopa.pn.papertracker.service.handler_step.RIR.HandlersFactoryRir;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Assertions;
@@ -72,7 +72,7 @@ class RECRN004CMessageHandlerTest extends BaseTest.WithLocalStack {
     @MockitoBean
     private DataVaultClient dataVaultClient;
     @MockitoBean
-    private ExternalChannelOutputsMomProducer externalChannelOutputsMomProducer;
+    private EventBridgePublisher eventBridgePublisher;
 
     private static final int DAYS_REFINEMENT = 10;
 
@@ -104,19 +104,19 @@ class RECRN004CMessageHandlerTest extends BaseTest.WithLocalStack {
         SingleStatusUpdate singleStatusUpdate = new SingleStatusUpdate();
         singleStatusUpdate.setAnalogMail(paperRequest);
 
-        ArgumentCaptor<DeliveryPushEvent> capturedSendEvent = ArgumentCaptor.forClass(DeliveryPushEvent.class);
+        ArgumentCaptor<PaperChannelUpdate> capturedSendEvent = ArgumentCaptor.forClass(PaperChannelUpdate.class);
 
         // Act
         externalChannelHandler.handleExternalChannelMessage(singleStatusUpdate, false, null, eventId, null);
 
         // Assert
-        verify(externalChannelOutputsMomProducer, times(2)).push(capturedSendEvent.capture());
+        verify(eventBridgePublisher, times(2)).publish(capturedSendEvent.capture());
         assertNotNull(capturedSendEvent.getAllValues());
         assertEquals(2, capturedSendEvent.getAllValues().size());
-        assertEquals(STATUS_PNRN012, capturedSendEvent.getAllValues().get(0).getPayload().getSendEvent().getStatusDetail());
-        assertEquals(StatusCodeEnum.OK, capturedSendEvent.getAllValues().get(0).getPayload().getSendEvent().getStatusCode());
-        assertEquals(STATUS_RECRN004C, capturedSendEvent.getAllValues().get(1).getPayload().getSendEvent().getStatusDetail());
-        assertEquals(StatusCodeEnum.PROGRESS, capturedSendEvent.getAllValues().get(1).getPayload().getSendEvent().getStatusCode());
+        assertEquals(STATUS_PNRN012, capturedSendEvent.getAllValues().get(0).getSendEvent().getStatusDetail());
+        assertEquals(StatusCodeEnum.OK, capturedSendEvent.getAllValues().get(0).getSendEvent().getStatusCode());
+        assertEquals(STATUS_RECRN004C, capturedSendEvent.getAllValues().get(1).getSendEvent().getStatusDetail());
+        assertEquals(StatusCodeEnum.PROGRESS, capturedSendEvent.getAllValues().get(1).getSendEvent().getStatusCode());
     }
 
     @Test
@@ -135,7 +135,7 @@ class RECRN004CMessageHandlerTest extends BaseTest.WithLocalStack {
         String requestId = "PREPARE_ANALOG_DOMICILE.IUN_" + iun + ".RECINDEX_0.ATTEMPT_0.PCRETRY_0";
         paperTrackingsDAO.putIfAbsent(getPaperTrackings(requestId, List.of(eventMetaRECRN010, eventMetaRECRN011, eventMetaRECRN004A, eventMetaRECRN004B))).block();
 
-        ArgumentCaptor<DeliveryPushEvent> capturedSendEvent = ArgumentCaptor.forClass(DeliveryPushEvent.class);
+        ArgumentCaptor<PaperChannelUpdate> capturedSendEvent = ArgumentCaptor.forClass(PaperChannelUpdate.class);
 
         PaperProgressStatusEvent paperRequest = new PaperProgressStatusEvent()
                 .requestId(requestId)
@@ -152,9 +152,9 @@ class RECRN004CMessageHandlerTest extends BaseTest.WithLocalStack {
         externalChannelHandler.handleExternalChannelMessage(singleStatusUpdate, false, null, eventId, null);
 
         // Assert
-        verify(externalChannelOutputsMomProducer).push(capturedSendEvent.capture());
+        verify(eventBridgePublisher).publish(capturedSendEvent.capture());
         log.info(capturedSendEvent.getAllValues().toString());
-        SendEvent sendEvent = capturedSendEvent.getValue().getPayload().getSendEvent();
+        SendEvent sendEvent = capturedSendEvent.getValue().getSendEvent();
         assertNotNull(sendEvent);
         Assertions.assertEquals(StatusCodeEnum.OK, sendEvent.getStatusCode());
         Assertions.assertEquals(STATUS_RECRN004C, sendEvent.getStatusDetail());

--- a/src/test/java/it/pagopa/pn/papertracker/service/handler_step/AR/RECRN005CMessageHandlerTest.java
+++ b/src/test/java/it/pagopa/pn/papertracker/service/handler_step/AR/RECRN005CMessageHandlerTest.java
@@ -4,18 +4,18 @@ import it.pagopa.pn.papertracker.BaseTest;
 import it.pagopa.pn.papertracker.exception.PaperTrackerExceptionHandler;
 import it.pagopa.pn.papertracker.generated.openapi.msclient.externalchannel.model.PaperProgressStatusEvent;
 import it.pagopa.pn.papertracker.generated.openapi.msclient.externalchannel.model.SingleStatusUpdate;
+import it.pagopa.pn.papertracker.generated.openapi.msclient.paperchannel.model.PaperChannelUpdate;
 import it.pagopa.pn.papertracker.generated.openapi.msclient.paperchannel.model.StatusCodeEnum;
 import it.pagopa.pn.papertracker.middleware.dao.PaperTrackerDryRunOutputsDAO;
 import it.pagopa.pn.papertracker.middleware.dao.PaperTrackingsDAO;
 import it.pagopa.pn.papertracker.middleware.dao.PaperTrackingsErrorsDAO;
 import it.pagopa.pn.papertracker.middleware.dao.dynamo.entity.Attachment;
 import it.pagopa.pn.papertracker.middleware.dao.dynamo.entity.Event;
+import it.pagopa.pn.papertracker.middleware.eventBridge.EventBridgePublisher;
 import it.pagopa.pn.papertracker.middleware.msclient.DataVaultClient;
 import it.pagopa.pn.papertracker.middleware.msclient.PaperChannelClient;
 import it.pagopa.pn.papertracker.middleware.msclient.SafeStorageClient;
 import it.pagopa.pn.papertracker.middleware.queue.consumer.internal.ExternalChannelHandler;
-import it.pagopa.pn.papertracker.middleware.queue.model.DeliveryPushEvent;
-import it.pagopa.pn.papertracker.middleware.queue.producer.ExternalChannelOutputsMomProducer;
 import it.pagopa.pn.papertracker.service.handler_step.RIR.HandlersFactoryRir;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Test;
@@ -77,7 +77,7 @@ class RECRN005CMessageHandlerTest extends BaseTest.WithLocalStack {
     @MockitoBean
     private DataVaultClient dataVaultClient;
     @MockitoBean
-    private ExternalChannelOutputsMomProducer externalChannelOutputsMomProducer;
+    private EventBridgePublisher eventBridgePublisher;
 
     @Test
     void should_pushPNRN012_when_RECRN005AGreaterOrEqualsRECRN010By30Days (){
@@ -106,18 +106,18 @@ class RECRN005CMessageHandlerTest extends BaseTest.WithLocalStack {
         SingleStatusUpdate singleStatusUpdate = new SingleStatusUpdate();
         singleStatusUpdate.setAnalogMail(paperRequest);
 
-        ArgumentCaptor<DeliveryPushEvent> capturedSendEvent = ArgumentCaptor.forClass(DeliveryPushEvent.class);
+        ArgumentCaptor<PaperChannelUpdate> capturedSendEvent = ArgumentCaptor.forClass(PaperChannelUpdate.class);
 
         // Act
         externalChannelHandler.handleExternalChannelMessage(singleStatusUpdate, false, null, eventId, null);
         // Assert
-        verify(externalChannelOutputsMomProducer, times(2)).push(capturedSendEvent.capture());
+        verify(eventBridgePublisher, times(2)).publish(capturedSendEvent.capture());
         assertNotNull(capturedSendEvent.getAllValues());
         assertEquals(2, capturedSendEvent.getAllValues().size());
-        assertEquals(STATUS_PNRN012, Objects.requireNonNull(capturedSendEvent.getAllValues().get(0).getPayload().getSendEvent()).getStatusDetail());
-        assertEquals(StatusCodeEnum.OK, Objects.requireNonNull(capturedSendEvent.getAllValues().get(0).getPayload().getSendEvent()).getStatusCode());
-        assertEquals(STATUS_RECRN005C, Objects.requireNonNull(capturedSendEvent.getAllValues().get(1).getPayload().getSendEvent()).getStatusDetail());
-        assertEquals(StatusCodeEnum.PROGRESS, Objects.requireNonNull(capturedSendEvent.getAllValues().get(1).getPayload().getSendEvent()).getStatusCode());
+        assertEquals(STATUS_PNRN012, Objects.requireNonNull(capturedSendEvent.getAllValues().get(0).getSendEvent()).getStatusDetail());
+        assertEquals(StatusCodeEnum.OK, Objects.requireNonNull(capturedSendEvent.getAllValues().get(0).getSendEvent()).getStatusCode());
+        assertEquals(STATUS_RECRN005C, Objects.requireNonNull(capturedSendEvent.getAllValues().get(1).getSendEvent()).getStatusDetail());
+        assertEquals(StatusCodeEnum.PROGRESS, Objects.requireNonNull(capturedSendEvent.getAllValues().get(1).getSendEvent()).getStatusCode());
     }
 
     @Test
@@ -151,7 +151,7 @@ class RECRN005CMessageHandlerTest extends BaseTest.WithLocalStack {
         externalChannelHandler.handleExternalChannelMessage(singleStatusUpdate, true, null, eventId, null);
 
         // Assert
-        verify(externalChannelOutputsMomProducer, never()).push(any(DeliveryPushEvent.class));
+        verify(eventBridgePublisher, never()).publish(any(PaperChannelUpdate.class));
 
 
     }
@@ -184,19 +184,19 @@ class RECRN005CMessageHandlerTest extends BaseTest.WithLocalStack {
         SingleStatusUpdate singleStatusUpdate = new SingleStatusUpdate();
         singleStatusUpdate.setAnalogMail(paperRequest);
 
-        ArgumentCaptor<DeliveryPushEvent> capturedSendEvent = ArgumentCaptor.forClass(DeliveryPushEvent.class);
+        ArgumentCaptor<PaperChannelUpdate> capturedSendEvent = ArgumentCaptor.forClass(PaperChannelUpdate.class);
 
         // Act
         externalChannelHandler.handleExternalChannelMessage(singleStatusUpdate, false, null, eventId, null);
 
         // Assert
-        verify(externalChannelOutputsMomProducer, times(2)).push(capturedSendEvent.capture());
+        verify(eventBridgePublisher, times(2)).publish(capturedSendEvent.capture());
         assertNotNull(capturedSendEvent.getAllValues());
         assertEquals(2, capturedSendEvent.getAllValues().size());
-        assertEquals(STATUS_PNRN012, Objects.requireNonNull(capturedSendEvent.getAllValues().get(0).getPayload().getSendEvent()).getStatusDetail());
-        assertEquals(StatusCodeEnum.OK, Objects.requireNonNull(capturedSendEvent.getAllValues().get(0).getPayload().getSendEvent()).getStatusCode());
-        assertEquals(STATUS_RECRN005C, Objects.requireNonNull(capturedSendEvent.getAllValues().get(1).getPayload().getSendEvent()).getStatusDetail());
-        assertEquals(StatusCodeEnum.PROGRESS, Objects.requireNonNull(capturedSendEvent.getAllValues().get(1).getPayload().getSendEvent()).getStatusCode());
+        assertEquals(STATUS_PNRN012, Objects.requireNonNull(capturedSendEvent.getAllValues().get(0).getSendEvent()).getStatusDetail());
+        assertEquals(StatusCodeEnum.OK, Objects.requireNonNull(capturedSendEvent.getAllValues().get(0).getSendEvent()).getStatusCode());
+        assertEquals(STATUS_RECRN005C, Objects.requireNonNull(capturedSendEvent.getAllValues().get(1).getSendEvent()).getStatusDetail());
+        assertEquals(StatusCodeEnum.PROGRESS, Objects.requireNonNull(capturedSendEvent.getAllValues().get(1).getSendEvent()).getStatusCode());
 
     }
 
@@ -233,7 +233,7 @@ class RECRN005CMessageHandlerTest extends BaseTest.WithLocalStack {
         externalChannelHandler.handleExternalChannelMessage(singleStatusUpdate, true, null, eventId, null);
 
         // Assert
-        verify(externalChannelOutputsMomProducer, never()).push(any(DeliveryPushEvent.class));
+        verify(eventBridgePublisher, never()).publish(any(PaperChannelUpdate.class));
     }
 
     private Event getEventMeta(String statusCode, Instant time) {

--- a/src/test/java/it/pagopa/pn/papertracker/service/handler_step/RIR/HandlersFactoryRirTest.java
+++ b/src/test/java/it/pagopa/pn/papertracker/service/handler_step/RIR/HandlersFactoryRirTest.java
@@ -43,7 +43,7 @@ class HandlersFactoryRirTest {
     private RetrySender retrySender;
 
     @Mock
-    private DeliveryPushSender deliveryPushSender;
+    private OutputTargetSender outputTargetSender;
 
     @Mock
     private IntermediateEventsBuilder intermediateEventsBuilder;
@@ -82,19 +82,19 @@ class HandlersFactoryRirTest {
         when(sequenceValidatorRir.execute(handlerContext)).thenReturn(Mono.empty());
         when(dematValidator.execute(handlerContext)).thenReturn(Mono.empty());
         when(finalEventBuilder.execute(handlerContext)).thenReturn(Mono.empty());
-        when(deliveryPushSender.execute(handlerContext)).thenReturn(Mono.empty());
+        when(outputTargetSender.execute(handlerContext)).thenReturn(Mono.empty());
 
         // Act
         StepVerifier.create(handlersFactoryRir.buildFinalEventsHandler(handlerContext).execute(handlerContext))
                 .verifyComplete();
 
         // Assert
-        InOrder inOrder = inOrder(metadataUpserter, sequenceValidatorRir, dematValidator, finalEventBuilder, deliveryPushSender);
+        InOrder inOrder = inOrder(metadataUpserter, sequenceValidatorRir, dematValidator, finalEventBuilder, outputTargetSender);
         inOrder.verify(metadataUpserter).execute(handlerContext);
         inOrder.verify(sequenceValidatorRir).execute(handlerContext);
         inOrder.verify(dematValidator).execute(handlerContext);
         inOrder.verify(finalEventBuilder).execute(handlerContext);
-        inOrder.verify(deliveryPushSender).execute(handlerContext);
+        inOrder.verify(outputTargetSender).execute(handlerContext);
     }
 
 
@@ -127,19 +127,19 @@ class HandlersFactoryRirTest {
         when(sequenceValidatorRir.execute(handlerContext)).thenReturn(Mono.empty());
         when(dematValidator.execute(handlerContext)).thenReturn(Mono.empty());
         when(finalEventBuilder.execute(handlerContext)).thenReturn(Mono.empty());
-        when(deliveryPushSender.execute(handlerContext)).thenReturn(Mono.empty());
+        when(outputTargetSender.execute(handlerContext)).thenReturn(Mono.empty());
 
         // Act
         StepVerifier.create(handlersFactoryRir.buildFinalEventsHandler(handlerContext).execute(handlerContext))
                 .verifyComplete();
 
         // Assert
-        InOrder inOrder = inOrder(metadataUpserter, sequenceValidatorRir, dematValidator, finalEventBuilder, deliveryPushSender);
+        InOrder inOrder = inOrder(metadataUpserter, sequenceValidatorRir, dematValidator, finalEventBuilder, outputTargetSender);
         inOrder.verify(metadataUpserter).execute(handlerContext);
         inOrder.verify(sequenceValidatorRir).execute(handlerContext);
         inOrder.verify(dematValidator).execute(handlerContext);
         inOrder.verify(finalEventBuilder).execute(handlerContext);
-        inOrder.verify(deliveryPushSender).execute(handlerContext);
+        inOrder.verify(outputTargetSender).execute(handlerContext);
     }
 
     @Test
@@ -148,7 +148,7 @@ class HandlersFactoryRirTest {
         when(metadataUpserter.execute(handlerContext)).thenReturn(Mono.empty());
         when(checkTrackingProduct.execute(handlerContext)).thenReturn(Mono.empty());
         when(checkTrackingState.execute(handlerContext)).thenReturn(Mono.empty());
-        when(deliveryPushSender.execute(handlerContext)).thenReturn(Mono.empty());
+        when(outputTargetSender.execute(handlerContext)).thenReturn(Mono.empty());
         when(intermediateEventsBuilder.execute(handlerContext)).thenReturn(Mono.empty());
         when(duplicatedEventFiltering.execute(handlerContext)).thenReturn(Mono.empty());
 
@@ -157,10 +157,10 @@ class HandlersFactoryRirTest {
                 .verifyComplete();
 
         // Verify both steps were executed in the correct order
-        InOrder inOrder = inOrder(metadataUpserter, intermediateEventsBuilder, deliveryPushSender);
+        InOrder inOrder = inOrder(metadataUpserter, intermediateEventsBuilder, outputTargetSender);
         inOrder.verify(metadataUpserter).execute(handlerContext);
         inOrder.verify(intermediateEventsBuilder).execute(handlerContext);
-        inOrder.verify(deliveryPushSender).execute(handlerContext);
+        inOrder.verify(outputTargetSender).execute(handlerContext);
     }
 
     @Test
@@ -170,7 +170,7 @@ class HandlersFactoryRirTest {
         when(checkTrackingProduct.execute(handlerContext)).thenReturn(Mono.empty());
         when(checkTrackingState.execute(handlerContext)).thenReturn(Mono.empty());
         when(retrySender.execute(handlerContext)).thenReturn(Mono.empty());
-        when(deliveryPushSender.execute(handlerContext)).thenReturn(Mono.empty());
+        when(outputTargetSender.execute(handlerContext)).thenReturn(Mono.empty());
         when(intermediateEventsBuilder.execute(handlerContext)).thenReturn(Mono.empty());
 
         // Act
@@ -190,7 +190,7 @@ class HandlersFactoryRirTest {
         when(checkTrackingProduct.execute(handlerContext)).thenReturn(Mono.empty());
         when(checkTrackingState.execute(handlerContext)).thenReturn(Mono.empty());
         when(duplicatedEventFiltering.execute(handlerContext)).thenReturn(Mono.empty());
-        when(deliveryPushSender.execute(handlerContext)).thenReturn(Mono.empty());
+        when(outputTargetSender.execute(handlerContext)).thenReturn(Mono.empty());
         when(intermediateEventsBuilder.execute(handlerContext)).thenReturn(Mono.empty());
         when(notRetryableErrorInserting.execute(handlerContext)).thenReturn(Mono.empty());
 
@@ -199,13 +199,13 @@ class HandlersFactoryRirTest {
                 .verifyComplete();
 
         // Assert
-        InOrder inOrder = inOrder(metadataUpserter, checkTrackingProduct, duplicatedEventFiltering, notRetryableErrorInserting, intermediateEventsBuilder, deliveryPushSender);
+        InOrder inOrder = inOrder(metadataUpserter, checkTrackingProduct, duplicatedEventFiltering, notRetryableErrorInserting, intermediateEventsBuilder, outputTargetSender);
         inOrder.verify(metadataUpserter).execute(handlerContext);
         inOrder.verify(checkTrackingProduct).execute(handlerContext);
         inOrder.verify(duplicatedEventFiltering).execute(handlerContext);
         inOrder.verify(notRetryableErrorInserting).execute(handlerContext);
         inOrder.verify(intermediateEventsBuilder).execute(handlerContext);
-        inOrder.verify(deliveryPushSender).execute(handlerContext);
+        inOrder.verify(outputTargetSender).execute(handlerContext);
     }
 
     @Test
@@ -213,7 +213,7 @@ class HandlersFactoryRirTest {
         // Arrange
         when(checkOcrResponse.execute(handlerContext)).thenReturn(Mono.empty());
         when(finalEventBuilder.execute(handlerContext)).thenReturn(Mono.empty());
-        when(deliveryPushSender.execute(handlerContext)).thenReturn(Mono.empty());
+        when(outputTargetSender.execute(handlerContext)).thenReturn(Mono.empty());
         // Act & Assert
         StepVerifier.create(handlersFactoryRir.buildOcrResponseHandler(handlerContext).execute(handlerContext))
                 .verifyComplete();

--- a/src/test/java/it/pagopa/pn/papertracker/service/handler_step/_890/HandlersFactory890Test.java
+++ b/src/test/java/it/pagopa/pn/papertracker/service/handler_step/_890/HandlersFactory890Test.java
@@ -27,7 +27,7 @@ class HandlersFactory890Test {
     private CheckTrackingProduct checkTrackingProduct;
 
     @Mock
-    private DeliveryPushSender deliveryPushSender;
+    private OutputTargetSender outputTargetSender;
 
     @Mock
     private FinalEventBuilder890 finalEventBuilder;
@@ -75,7 +75,7 @@ class HandlersFactory890Test {
         handlersFactory = new HandlersFactory890(
                 metadataUpserter,
                 checkTrackingProduct,
-                deliveryPushSender,
+                outputTargetSender,
                 finalEventBuilder,
                 intermediateEventsBuilder,
                 dematValidator,

--- a/src/test/java/it/pagopa/pn/papertracker/service/handler_step/generic/OutputTargetSenderTest.java
+++ b/src/test/java/it/pagopa/pn/papertracker/service/handler_step/generic/OutputTargetSenderTest.java
@@ -2,6 +2,7 @@ package it.pagopa.pn.papertracker.service.handler_step.generic;
 
 import it.pagopa.pn.papertracker.config.PnPaperTrackerConfigs;
 import it.pagopa.pn.papertracker.generated.openapi.msclient.paperchannel.model.AttachmentDetails;
+import it.pagopa.pn.papertracker.generated.openapi.msclient.paperchannel.model.PaperChannelUpdate;
 import it.pagopa.pn.papertracker.generated.openapi.msclient.paperchannel.model.SendEvent;
 import it.pagopa.pn.papertracker.generated.openapi.msclient.paperchannel.model.StatusCodeEnum;
 import it.pagopa.pn.papertracker.middleware.dao.PaperTrackerDryRunOutputsDAO;
@@ -9,8 +10,7 @@ import it.pagopa.pn.papertracker.middleware.dao.PaperTrackingsDAO;
 import it.pagopa.pn.papertracker.middleware.dao.dynamo.entity.PaperStatus;
 import it.pagopa.pn.papertracker.middleware.dao.dynamo.entity.PaperTrackings;
 import it.pagopa.pn.papertracker.middleware.dao.dynamo.entity.PaperTrackingsState;
-import it.pagopa.pn.papertracker.middleware.queue.model.DeliveryPushEvent;
-import it.pagopa.pn.papertracker.middleware.queue.producer.ExternalChannelOutputsMomProducer;
+import it.pagopa.pn.papertracker.middleware.eventBridge.EventBridgePublisher;
 import it.pagopa.pn.papertracker.model.HandlerContext;
 import it.pagopa.pn.papertracker.utils.LogUtility;
 import org.junit.jupiter.api.Assertions;
@@ -29,7 +29,7 @@ import static org.mockito.Mockito.*;
 import static org.mockito.Mockito.times;
 
 @ExtendWith(MockitoExtension.class)
-class DeliveryPushSenderTest {
+class OutputTargetSenderTest {
 
     @Mock
     private PnPaperTrackerConfigs config;
@@ -41,13 +41,13 @@ class DeliveryPushSenderTest {
     private PaperTrackingsDAO paperTrackingsDAO;
 
     @Mock
-    private ExternalChannelOutputsMomProducer externalChannelOutputsMomProducer;
+    private EventBridgePublisher eventBridgePublisher;
 
     @Mock
     private LogUtility logUtility;
 
     @InjectMocks
-    private DeliveryPushSender deliveryPushSender;
+    private OutputTargetSender outputTargetSender;
 
     @Test
     void testSendToOutputTarget_SendToExternalChannelOutputs() {
@@ -58,10 +58,10 @@ class DeliveryPushSenderTest {
         context.setPaperTrackings(paperTrackings);
 
         // Act
-        deliveryPushSender.sendToOutputTarget(event, context).block();
+        outputTargetSender.sendToOutputTarget(event, context).block();
 
         // Assert
-        verify(externalChannelOutputsMomProducer, times(1)).push(any(DeliveryPushEvent.class));
+        verify(eventBridgePublisher, times(1)).publish(any(PaperChannelUpdate.class));
         verify(paperTrackerDryRunOutputsDAO, never()).insertOutputEvent(any());
         verifyNoInteractions(paperTrackingsDAO);
     }
@@ -79,11 +79,11 @@ class DeliveryPushSenderTest {
         when(paperTrackerDryRunOutputsDAO.insertOutputEvent(any())).thenReturn(Mono.empty());
 
         // Act
-        deliveryPushSender.sendToOutputTarget(event, context).block();
+        outputTargetSender.sendToOutputTarget(event, context).block();
 
         // Assert
         verify(paperTrackerDryRunOutputsDAO, times(1)).insertOutputEvent(any());
-        verify(externalChannelOutputsMomProducer, never()).push(any(DeliveryPushEvent.class));
+        verify(eventBridgePublisher, never()).publish(any(PaperChannelUpdate.class));
         verifyNoInteractions(paperTrackingsDAO);
     }
 
@@ -96,12 +96,12 @@ class DeliveryPushSenderTest {
         context.setPaperTrackings(paperTrackings);
 
         // Act
-        deliveryPushSender.sendToOutputTarget(event, context).block();
+        outputTargetSender.sendToOutputTarget(event, context).block();
 
         // Assert
-        ArgumentCaptor<DeliveryPushEvent> captor = ArgumentCaptor.forClass(DeliveryPushEvent.class);
-        verify(externalChannelOutputsMomProducer).push(captor.capture());
-        Assertions.assertEquals(event, captor.getValue().getPayload().getSendEvent());
+        ArgumentCaptor<PaperChannelUpdate> captor = ArgumentCaptor.forClass(PaperChannelUpdate.class);
+        verify(eventBridgePublisher).publish(captor.capture());
+        Assertions.assertEquals(event, captor.getValue().getSendEvent());
         verifyNoInteractions(paperTrackingsDAO);
     }
 
@@ -115,10 +115,10 @@ class DeliveryPushSenderTest {
         context.setEventsToSend(Collections.singletonList(event));
 
         // Act
-        deliveryPushSender.execute(context).block();
+        outputTargetSender.execute(context).block();
 
         // Assert
-        verify(externalChannelOutputsMomProducer, times(1)).push(any(DeliveryPushEvent.class));
+        verify(eventBridgePublisher, times(1)).publish(any(PaperChannelUpdate.class));
         verify(paperTrackerDryRunOutputsDAO, never()).insertOutputEvent(any());
         verify(paperTrackingsDAO, never()).updateItem(anyString(), any(PaperTrackings.class));
         verifyNoInteractions(paperTrackingsDAO);
@@ -130,10 +130,10 @@ class DeliveryPushSenderTest {
         HandlerContext context = getFinalEventHandlerContext();
         when(paperTrackingsDAO.updateItem(any(), any())).thenReturn(Mono.just(new PaperTrackings()));
         // Act
-        deliveryPushSender.execute(context).block();
+        outputTargetSender.execute(context).block();
 
         // Assert
-        verify(externalChannelOutputsMomProducer, times(1)).push(any(DeliveryPushEvent.class));
+        verify(eventBridgePublisher, times(1)).publish(any(PaperChannelUpdate.class));
         verify(paperTrackerDryRunOutputsDAO, never()).insertOutputEvent(any());
         ArgumentCaptor<PaperTrackings> captor = ArgumentCaptor.forClass(PaperTrackings.class);
         verify(paperTrackingsDAO, times(1)).updateItem(any(), captor.capture());
@@ -146,10 +146,10 @@ class DeliveryPushSenderTest {
         HandlerContext context = getPcRetryHandlerContext();
         when(paperTrackingsDAO.updateItem(any(), any())).thenReturn(Mono.just(new PaperTrackings()));
         // Act
-        deliveryPushSender.execute(context).block();
+        outputTargetSender.execute(context).block();
 
         // Assert
-        verify(externalChannelOutputsMomProducer, times(1)).push(any(DeliveryPushEvent.class));
+        verify(eventBridgePublisher, times(1)).publish(any(PaperChannelUpdate.class));
         verify(paperTrackerDryRunOutputsDAO, never()).insertOutputEvent(any());
         ArgumentCaptor<PaperTrackings> captor = ArgumentCaptor.forClass(PaperTrackings.class);
         verify(paperTrackingsDAO, times(1)).updateItem(any(), captor.capture());


### PR DESCRIPTION
[PN-19218] - Added EventBridgePublisher instead of queue producer in OutputTargetSender

[PN-19218]: https://pagopa.atlassian.net/browse/PN-19218?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ