### PR TITLE
fix(PN-20664): filtra eventi duplicati sull'inoltro a pn-paper-channel

### DIFF
--- a/docs/ms/ArchitetturaInterna.md
+++ b/docs/ms/ArchitetturaInterna.md
@@ -29,10 +29,10 @@ che si occupa di gestire il routing degli eventi provenienti da pn-ec in base al
 (attributo `processingMode` della classe [`PaperTrackings`](../../src/main/java/it/pagopa/pn/papertracker/middleware/dao/dynamo/entity/PaperTrackings.java)).
 
 La logica applicata è la seguente:
-- **Spedizione NON presente su pn-PaperTrackings**: l'evento viene inoltrato solo a pn-paper-channel.
-- **Spedizione presente e modalità DRY**: l'evento viene inoltrato sia a pn-paper-channel che a pn-paper-tracker.
+- **Spedizione NON presente su pn-PaperTrackings**: l'evento viene inoltrato solo a pn-paper-channel, unicamente se non è un duplicato (`isDuplicate == false` oppure `isDuplicate == null`).
+- **Spedizione presente e modalità DRY**: l'evento viene inoltrato a pn-paper-tracker e a pn-paper-channel; l'inoltro a pn-paper-channel avviene solo se l'evento non è un duplicato (`isDuplicate == false` oppure `isDuplicate == null`).
 - **Spedizione presente e modalità RUN**: l'evento viene inoltrato solo a pn-paper-tracker.
-- **Spedizione con processingMode null**: l'evento viene gestito come in modalità DRY.
+- **Spedizione con processingMode null**: l'evento viene gestito come in modalità DRY (inoltro a pn-paper-tracker e, solo se non duplicato, a pn-paper-channel).
 
 Il messaggio viene arricchito con header e flag dry-run, e inoltrato ai consumer appropriati tramite i producer dedicati.
 

--- a/docs/openapi/external-channel/schemas-paper-v1.yaml
+++ b/docs/openapi/external-channel/schemas-paper-v1.yaml
@@ -302,6 +302,11 @@ components:
           format: date-time
           description: >-
             Timestamp della richiesta in UTC
+        isDuplicate:
+          type: boolean
+          description: >-
+            Indica se l'evento risulta duplicato rispetto agli eventi già presenti sulla richiesta.
+            Valorizzato sempre da pn-ec per gli eventi analogici.
     
 
     AttachmentDetails:

--- a/docs/openapi/external-channel/schemas-paper-v1.yaml
+++ b/docs/openapi/external-channel/schemas-paper-v1.yaml
@@ -304,6 +304,7 @@ components:
             Timestamp della richiesta in UTC
         isDuplicate:
           type: boolean
+          nullable: true
           description: >-
             Indica se l'evento risulta duplicato rispetto agli eventi già presenti sulla richiesta.
             Valorizzato sempre da pn-ec per gli eventi analogici.

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 		<relativePath />
 	</parent>
 	<artifactId>pn-paper-tracker</artifactId>
-	<version>1.6.0</version>
+	<version>1.6.1-SNAPSHOT</version>
 	<name>pn-paper-tracker</name>
 	<description>PN paper-tracker Microservice</description>
 	<scm>

--- a/src/main/java/it/pagopa/pn/papertracker/middleware/queue/consumer/internal/ExternalChannelSourceEventsHandler.java
+++ b/src/main/java/it/pagopa/pn/papertracker/middleware/queue/consumer/internal/ExternalChannelSourceEventsHandler.java
@@ -33,7 +33,7 @@ import java.util.Objects;
  *   </li>
  *   <li>
  *     <b>Spedizione presente su pn-PaperTrackings e modalità DRY</b><br>
- *     L'evento viene inoltrato a pn-paper-channel e, in parallelo, processato internamente
+ *     L'evento viene inoltrato a pn-paper-channel (se non duplicato) e, in parallelo, processato internamente
  *     da pn-paper-tracker, con persistenza dell'output su tabella a fini di verifica.
  *   </li>
  *   <li>

--- a/src/main/java/it/pagopa/pn/papertracker/service/impl/SourceQueueProxyServiceImpl.java
+++ b/src/main/java/it/pagopa/pn/papertracker/service/impl/SourceQueueProxyServiceImpl.java
@@ -44,9 +44,10 @@ public class SourceQueueProxyServiceImpl implements SourceQueueProxyService {
      * <p>
      * Le regole applicate sono:
      * <ul>
-     *   <li>Spedizione NON presente su pn-PaperTrackings -> evento inoltrato solo a pn-paper-channel</li>
-     *   <li>Spedizione presente e modalità DRY -> evento inoltrato a pn-paper-channel e pn-paper-tracker</li>
+     *   <li>Spedizione NON presente su pn-PaperTrackings -> evento inoltrato solo a pn-paper-channel (se non duplicato)</li>
+     *   <li>Spedizione presente e modalità DRY -> evento inoltrato a pn-paper-channel (se non duplicato) e pn-paper-tracker</li>
      *   <li>Spedizione presente e modalità RUN -> evento inoltrato solo a pn-paper-tracker</li>
+     *   <li>Spedizione presente e processingMode null -> evento inoltrato a pn-paper-channel (se non duplicato) e pn-paper-tracker</li>
      * </ul>
      * </p>
      *
@@ -77,24 +78,27 @@ public class SourceQueueProxyServiceImpl implements SourceQueueProxyService {
 
     /**
      * Gestisce un evento quando il tracking non è presente su pn-PaperTrackings.
-     * L'evento viene inoltrato direttamente a pn-paper-channel in modalità dry-run.
+     * L'evento viene inoltrato a pn-paper-channel in modalità dry-run solo se non è un duplicato
+     * (isDuplicate == false o isDuplicate == null).
      *
      * @param event l'evento da inoltrare
      * @return Mono<Void>
      */
     private Mono<Void> handlePaperChannelEvent(SingleStatusUpdate event,
                                                Map<String, MessageAttributeValue> messageAttributes) {
-        return Mono.fromRunnable(() ->
-                paperChannelDryRunProducer.push(buildOutputMessage(event, messageAttributes,true))
-        );
+        return Mono.fromRunnable(() -> {
+            if (shouldForwardToPaperChannel(event)) {
+                paperChannelDryRunProducer.push(buildOutputMessage(event, messageAttributes, true));
+            }
+        });
     }
 
     /**
      * Gestisce l'evento in base alla modalità operativa (DRY o RUN) recuperata dal tracking.
      * <p>
-     * Modalità DRY: l'evento viene inoltrato sia a pn-paper-channel che a pn-paper-tracker.
+     * Modalità DRY: l'evento viene inoltrato a pn-paper-tracker e a pn-paper-channel solo se non duplicato.
      * Modalità RUN: l'evento viene inviato solo a pn-paper-tracker.
-     * Null: spedizioni inizializzate prima della GA26Q1.A
+     * Null: spedizioni inizializzate prima della GA26Q1.A, stesse regole di DRY per l'inoltro a pn-paper-channel.
      * </p>
      *
      * @param tracking oggetto della spedizione
@@ -110,7 +114,9 @@ public class SourceQueueProxyServiceImpl implements SourceQueueProxyService {
         return switch (tracking.getProcessingMode()) {
             case DRY -> Mono.fromRunnable(() -> {
                 var enrichedMessage = buildOutputMessage(event, messageAttributes, true);
-                paperChannelDryRunProducer.push(enrichedMessage);
+                if (shouldForwardToPaperChannel(event)) {
+                    paperChannelDryRunProducer.push(enrichedMessage);
+                }
                 paperTrackerProducer.push(enrichedMessage);
             });
             case RUN -> Mono.fromRunnable(() ->
@@ -119,10 +125,26 @@ public class SourceQueueProxyServiceImpl implements SourceQueueProxyService {
             case null -> Mono.fromRunnable(() -> {
                 log.info("Tracking entity created without processignMode, createdAt: {}", tracking.getCreatedAt());
                 var enrichedMessage = buildOutputMessage(event, messageAttributes, true);
-                paperChannelDryRunProducer.push(enrichedMessage);
+                if (shouldForwardToPaperChannel(event)) {
+                    paperChannelDryRunProducer.push(enrichedMessage);
+                }
                 paperTrackerProducer.push(enrichedMessage);
             });
         };
+    }
+
+    /**
+     * Determina se l'evento deve essere inoltrato a pn-paper-channel.
+     * L'evento viene inoltrato solo se non è un duplicato (isDuplicate == false o isDuplicate == null).
+     *
+     * @param event l'evento da verificare
+     * @return true se l'evento deve essere inoltrato a pn-paper-channel
+     */
+    private boolean shouldForwardToPaperChannel(SingleStatusUpdate event) {
+        Boolean isDuplicate = event.getAnalogMail() != null
+                ? event.getAnalogMail().getIsDuplicate()
+                : null;
+        return !Boolean.TRUE.equals(isDuplicate);
     }
 
     /**

--- a/src/main/java/it/pagopa/pn/papertracker/service/impl/SourceQueueProxyServiceImpl.java
+++ b/src/main/java/it/pagopa/pn/papertracker/service/impl/SourceQueueProxyServiceImpl.java
@@ -59,14 +59,18 @@ public class SourceQueueProxyServiceImpl implements SourceQueueProxyService {
             SingleStatusUpdate message,
             Map<String, MessageAttributeValue> messageAttributes
     ) {
-        log.info("Routing message");
-
         String requestId;
         try {
             requestId = message.getAnalogMail().getRequestId();
         } catch (NullPointerException e) {
             return Mono.error(new PaperTrackerException("Malformed event from external-channel", e));
         }
+
+        log.info("Routing message - requestId: {}, statusCode: {}, isDuplicate: {}, clientRequestTimeStamp: {}",
+                requestId, 
+                message.getAnalogMail().getStatusCode(), 
+                message.getAnalogMail().getIsDuplicate(),
+                message.getAnalogMail().getClientRequestTimeStamp());
 
         return paperTrackingsDAO.retrieveEntityByTrackingId(requestId)
                 // caso: tracking NON trovato
@@ -112,25 +116,40 @@ public class SourceQueueProxyServiceImpl implements SourceQueueProxyService {
             Map<String, MessageAttributeValue> messageAttributes
     ) {
         return switch (tracking.getProcessingMode()) {
-            case DRY -> Mono.fromRunnable(() -> {
-                var enrichedMessage = buildOutputMessage(event, messageAttributes, true);
-                if (shouldForwardToPaperChannel(event)) {
-                    paperChannelDryRunProducer.push(enrichedMessage);
-                }
-                paperTrackerProducer.push(enrichedMessage);
-            });
+            case DRY -> Mono.fromRunnable(() -> forwardInDryRun(tracking, event, messageAttributes));
             case RUN -> Mono.fromRunnable(() ->
                     paperTrackerProducer.push(buildOutputMessage(event, messageAttributes, false))
             );
             case null -> Mono.fromRunnable(() -> {
                 log.info("Tracking entity created without processignMode, createdAt: {}", tracking.getCreatedAt());
-                var enrichedMessage = buildOutputMessage(event, messageAttributes, true);
-                if (shouldForwardToPaperChannel(event)) {
-                    paperChannelDryRunProducer.push(enrichedMessage);
-                }
-                paperTrackerProducer.push(enrichedMessage);
+                forwardInDryRun(tracking, event, messageAttributes);
             });
         };
+    }
+
+    /**
+     * Inoltra l'evento in modalità dry-run a pn-paper-tracker e, solo se non è un duplicato
+     * (isDuplicate == false o isDuplicate == null), anche a pn-paper-channel.
+     *
+     * @param tracking oggetto della spedizione
+     * @param event l'evento da inoltrare
+     * @param messageAttributes attributi del messaggio
+     */
+    private void forwardInDryRun(
+            PaperTrackings tracking,
+            SingleStatusUpdate event,
+            Map<String, MessageAttributeValue> messageAttributes
+    ) {
+        var enrichedMessage = buildOutputMessage(event, messageAttributes, true);
+        if (shouldForwardToPaperChannel(event)) {
+            paperChannelDryRunProducer.push(enrichedMessage);
+        } else {
+            log.info("Event is duplicate, not forwarding to paper-channel, requestId: {}, statusCode: {}, clientRequestTimeStamp: {}",
+                    tracking.getTrackingId(),
+                    event.getAnalogMail().getStatusCode(),
+                    event.getAnalogMail().getClientRequestTimeStamp());
+        }
+        paperTrackerProducer.push(enrichedMessage);
     }
 
     /**

--- a/src/test/java/it/pagopa/pn/papertracker/service/impl/SourceQueueProxyServiceImplTest.java
+++ b/src/test/java/it/pagopa/pn/papertracker/service/impl/SourceQueueProxyServiceImplTest.java
@@ -323,4 +323,160 @@ class SourceQueueProxyServiceImplTest {
         ExternalChannelEvent event = eventCaptor.getValue();
         assertNotNull(event.getHeader().getMessageAttributes());
     }
+
+    // ===== Test filtro eventi duplicati (isDuplicate) =====
+
+    @Test
+    void handleExternalChannelMessage_trackingNotFound_duplicate_shouldNotSend() {
+        // Arrange
+        analogMail.setIsDuplicate(true);
+        when(paperTrackingsDAO.retrieveEntityByTrackingId(REQUEST_ID))
+                .thenReturn(Mono.empty());
+
+        // Act
+        Mono<Void> result = service.handleExternalChannelMessage(message, attributes);
+
+        // Assert
+        StepVerifier.create(result).verifyComplete();
+
+        verify(paperChannelDryRunProducer, never()).push(any(ExternalChannelEvent.class));
+        verify(paperTrackerProducer, never()).push(any(ExternalChannelEvent.class));
+    }
+
+    @Test
+    void handleExternalChannelMessage_trackingNotFound_notDuplicate_shouldSendToPaperChannelOnly() {
+        // Arrange
+        analogMail.setIsDuplicate(false);
+        when(paperTrackingsDAO.retrieveEntityByTrackingId(REQUEST_ID))
+                .thenReturn(Mono.empty());
+
+        // Act
+        Mono<Void> result = service.handleExternalChannelMessage(message, attributes);
+
+        // Assert
+        StepVerifier.create(result).verifyComplete();
+
+        verify(paperChannelDryRunProducer, times(1)).push(any(ExternalChannelEvent.class));
+        verify(paperTrackerProducer, never()).push(any(ExternalChannelEvent.class));
+    }
+
+    @Test
+    void handleExternalChannelMessage_dryMode_duplicate_shouldSendToPaperTrackerOnly() {
+        // Arrange
+        analogMail.setIsDuplicate(true);
+        PaperTrackings tracking = new PaperTrackings();
+        tracking.setProcessingMode(ProcessingMode.DRY);
+        tracking.setTrackingId(REQUEST_ID);
+        when(paperTrackingsDAO.retrieveEntityByTrackingId(REQUEST_ID))
+                .thenReturn(Mono.just(tracking));
+
+        // Act
+        Mono<Void> result = service.handleExternalChannelMessage(message, attributes);
+
+        // Assert
+        StepVerifier.create(result).verifyComplete();
+
+        verify(paperChannelDryRunProducer, never()).push(any(ExternalChannelEvent.class));
+        verify(paperTrackerProducer, times(1)).push(any(ExternalChannelEvent.class));
+    }
+
+    @Test
+    void handleExternalChannelMessage_dryMode_notDuplicate_shouldSendToBothQueues() {
+        // Arrange
+        analogMail.setIsDuplicate(false);
+        PaperTrackings tracking = new PaperTrackings();
+        tracking.setProcessingMode(ProcessingMode.DRY);
+        tracking.setTrackingId(REQUEST_ID);
+        when(paperTrackingsDAO.retrieveEntityByTrackingId(REQUEST_ID))
+                .thenReturn(Mono.just(tracking));
+
+        // Act
+        Mono<Void> result = service.handleExternalChannelMessage(message, attributes);
+
+        // Assert
+        StepVerifier.create(result).verifyComplete();
+
+        verify(paperChannelDryRunProducer, times(1)).push(any(ExternalChannelEvent.class));
+        verify(paperTrackerProducer, times(1)).push(any(ExternalChannelEvent.class));
+    }
+
+    @Test
+    void handleExternalChannelMessage_runMode_notDuplicate_shouldSendToPaperTrackerOnly() {
+        // Arrange
+        analogMail.setIsDuplicate(false);
+        PaperTrackings tracking = new PaperTrackings();
+        tracking.setProcessingMode(ProcessingMode.RUN);
+        tracking.setTrackingId(REQUEST_ID);
+        when(paperTrackingsDAO.retrieveEntityByTrackingId(REQUEST_ID))
+                .thenReturn(Mono.just(tracking));
+
+        // Act
+        Mono<Void> result = service.handleExternalChannelMessage(message, attributes);
+
+        // Assert
+        StepVerifier.create(result).verifyComplete();
+
+        verify(paperTrackerProducer, times(1)).push(any(ExternalChannelEvent.class));
+        verify(paperChannelDryRunProducer, never()).push(any(ExternalChannelEvent.class));
+    }
+
+    @Test
+    void handleExternalChannelMessage_runMode_duplicate_shouldSendToPaperTrackerOnly() {
+        // Arrange
+        analogMail.setIsDuplicate(true);
+        PaperTrackings tracking = new PaperTrackings();
+        tracking.setProcessingMode(ProcessingMode.RUN);
+        tracking.setTrackingId(REQUEST_ID);
+        when(paperTrackingsDAO.retrieveEntityByTrackingId(REQUEST_ID))
+                .thenReturn(Mono.just(tracking));
+
+        // Act
+        Mono<Void> result = service.handleExternalChannelMessage(message, attributes);
+
+        // Assert
+        StepVerifier.create(result).verifyComplete();
+
+        verify(paperTrackerProducer, times(1)).push(any(ExternalChannelEvent.class));
+        verify(paperChannelDryRunProducer, never()).push(any(ExternalChannelEvent.class));
+    }
+
+    @Test
+    void handleExternalChannelMessage_nullProcessingMode_duplicate_shouldSendToPaperTrackerOnly() {
+        // Arrange
+        analogMail.setIsDuplicate(true);
+        PaperTrackings tracking = new PaperTrackings();
+        tracking.setProcessingMode(null);
+        tracking.setTrackingId(REQUEST_ID);
+        when(paperTrackingsDAO.retrieveEntityByTrackingId(REQUEST_ID))
+                .thenReturn(Mono.just(tracking));
+
+        // Act
+        Mono<Void> result = service.handleExternalChannelMessage(message, attributes);
+
+        // Assert
+        StepVerifier.create(result).verifyComplete();
+
+        verify(paperChannelDryRunProducer, never()).push(any(ExternalChannelEvent.class));
+        verify(paperTrackerProducer, times(1)).push(any(ExternalChannelEvent.class));
+    }
+
+    @Test
+    void handleExternalChannelMessage_nullProcessingMode_notDuplicate_shouldSendToBothQueues() {
+        // Arrange
+        analogMail.setIsDuplicate(false);
+        PaperTrackings tracking = new PaperTrackings();
+        tracking.setProcessingMode(null);
+        tracking.setTrackingId(REQUEST_ID);
+        when(paperTrackingsDAO.retrieveEntityByTrackingId(REQUEST_ID))
+                .thenReturn(Mono.just(tracking));
+
+        // Act
+        Mono<Void> result = service.handleExternalChannelMessage(message, attributes);
+
+        // Assert
+        StepVerifier.create(result).verifyComplete();
+
+        verify(paperChannelDryRunProducer, times(1)).push(any(ExternalChannelEvent.class));
+        verify(paperTrackerProducer, times(1)).push(any(ExternalChannelEvent.class));
+    }
 }


### PR DESCRIPTION
Aggiunge il campo isDuplicate a PaperProgressStatusEvent e ne utilizza il valore in SourceQueueProxyServiceImpl per evitare l'inoltro di eventi duplicati verso pn-paper-channel tramite la coda dry-run.

L'evento viene inoltrato a pn-paper-channel solo se non è un duplicato (isDuplicate == false oppure isDuplicate == null) nei casi:
- spedizione non presente su pn-PaperTrackings
- spedizione con processingMode DRY
- spedizione con processingMode null

Il flusso RUN resta invariato (nessun inoltro a pn-paper-channel).

Aggiorna la documentazione in docs/ms/ArchitetturaInterna.md e aggiunge i test per tutte le combinazioni di stato/isDuplicate.